### PR TITLE
wear投稿時の一覧表示の非同期更新機能実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 /yarn-error.log
 
 /public/assets
+/public/uploads
 .byebug_history
 
 # Ignore master key for decrypting credentials and more.

--- a/app/controllers/wears_controller.rb
+++ b/app/controllers/wears_controller.rb
@@ -1,6 +1,6 @@
 class WearsController < ApplicationController
   def index
-    @wears = Wear.all
+    @wears = Wear.all.order("created_at DESC")
   end
 
   def create

--- a/app/javascript/packs/components/closet.jsx
+++ b/app/javascript/packs/components/closet.jsx
@@ -11,9 +11,14 @@ class Closet extends Component {
       isClick: false,
     }
     this.handleClickButton = this.handleClickButton.bind(this)
+    this.getWearIndex      = this.getWearIndex.bind(this)
   }
 
   componentDidMount() {
+    this.getWearIndex();
+  }
+
+  getWearIndex(){
     axios.get('/wears')
     .then(res=>{
       this.setState({wears: res.data})
@@ -28,6 +33,10 @@ class Closet extends Component {
     this.setState({isClick: false});
   }
 
+  addWearInfo(){
+    this.getWearIndex();
+  }
+
   render() {
     var modal;
     var wear_cards = [];
@@ -35,6 +44,7 @@ class Closet extends Component {
     if (this.state.isClick){
       modal = <WearRegistModal
                 closeModal={()=>{this.closeModal();}}
+                addWearInfo={()=>{this.addWearInfo();}}
               />
     }
 

--- a/app/javascript/packs/components/wear_regist_modal.jsx
+++ b/app/javascript/packs/components/wear_regist_modal.jsx
@@ -50,6 +50,7 @@ class WearRegistModal extends Component {
                {headers: {'content-type': 'multipart/form-data',}}
               )
     .then(res=>{
+      this.props.addWearInfo();
       this.props.closeModal();
     },error=>{
       console.info(error);


### PR DESCRIPTION
#What
wearを投稿した際に、一覧表示が非同期で更新される機能を実装。
#Why
今までは、投稿後、画面更新を行わなければ投稿した内容を閲覧できなかったが、本実装により投稿直後に一覧表示されるようになっている。
この機能によってUX向上が見込める。